### PR TITLE
Fixed a compilation error in 'Locatable'

### DIFF
--- a/Locatable/Locatable/Locatable.swift
+++ b/Locatable/Locatable/Locatable.swift
@@ -55,7 +55,7 @@ public struct Locatable<Service> {
         self.locatingMode = locatingMode
     }
     
-    public var value: Service {
+    public var wrappedValue: Service {
         get {
             return Locator.locate(Service.self, locatingMode: locatingMode)
         }


### PR DESCRIPTION
Fixed a Swift 5 compilation error in 'Locatable' which was complaining of wrapper type 'Locatable' missing a non-static property named 'wrappedValue'. Renaming the `Locatable.value` property to `Locatable.wrappedValue` fixes it.